### PR TITLE
fix: restore end-to-end trading pipeline + stability hardening

### DIFF
--- a/dashboard_generator.py
+++ b/dashboard_generator.py
@@ -2,121 +2,103 @@
 """
 Real-time Performance Dashboard Generator
 Creates HTML dashboard with live metrics
+
+Uses Supabase REST as single data plane.
 """
 
-import json
-import os
-import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 
-import db_patch  # noqa: F401, E402 — must import before psycopg2
-import psycopg2
-from dotenv import load_dotenv
+from supabase_client import is_available, select
 
-load_dotenv()
 
-DB_URL = os.getenv("DATABASE_URL", "postgresql://localhost/chainlens")
+def _to_float(v, default: float = 0.0) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
 
 
 class DashboardGenerator:
     def __init__(self):
-        self.conn = psycopg2.connect(DB_URL)
-    
+        if not is_available():
+            raise RuntimeError("Supabase REST not configured. Set SUPABASE_URL and SUPABASE_SERVICE_KEY")
+
     def get_system_stats(self) -> Dict:
         """Get overall system statistics."""
-        cur = self.conn.cursor()
-        
-        # Total signals
-        cur.execute("SELECT COUNT(*) FROM signals WHERE timestamp >= NOW() - INTERVAL '24 hours'")
-        signals_24h = cur.fetchone()[0]
-        
-        # Total trades
-        cur.execute("SELECT COUNT(*) FROM trades WHERE opened_at >= NOW() - INTERVAL '24 hours'")
-        trades_24h = cur.fetchone()[0]
-        
+        cutoff_24h = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        cutoff_7d = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+
+        # Signals in last 24h
+        sig_rows = select("signals", columns="id", filters={"timestamp": f"gte.{cutoff_24h}"}, limit=10000)
+        signals_24h = len(sig_rows)
+
+        # Trades in last 24h
+        trade_rows = select("trades", columns="id", filters={"opened_at": f"gte.{cutoff_24h}"}, limit=10000)
+        trades_24h = len(trade_rows)
+
         # Open positions
-        cur.execute("SELECT COUNT(*) FROM trades WHERE status = 'open'")
-        open_positions = cur.fetchone()[0]
-        
-        # Win rate (last 7 days)
-        cur.execute("""
-            SELECT 
-                COUNT(*) FILTER (WHERE pnl_pct > 0) as wins,
-                COUNT(*) as total
-            FROM trades
-            WHERE status = 'closed'
-              AND opened_at >= NOW() - INTERVAL '7 days'
-        """)
-        row = cur.fetchone()
-        wins, total = row[0] or 0, row[1] or 0
+        open_rows = select("trades", columns="id", filters={"status": "eq.open"}, limit=10000)
+        open_positions = len(open_rows)
+
+        # Win rate and PnL (last 7 days, closed trades)
+        closed_rows = select(
+            "trades",
+            columns="pnl_pct",
+            filters={"status": "eq.closed", "opened_at": f"gte.{cutoff_7d}"},
+            limit=10000,
+        )
+        total = len(closed_rows)
+        wins = sum(1 for r in closed_rows if _to_float(r.get("pnl_pct")) > 0)
         win_rate = (wins / total * 100) if total > 0 else 0
-        
-        # Total PnL (last 7 days)
-        cur.execute("""
-            SELECT COALESCE(SUM(pnl_pct), 0)
-            FROM trades
-            WHERE status = 'closed'
-              AND opened_at >= NOW() - INTERVAL '7 days'
-        """)
-        total_pnl = cur.fetchone()[0]
-        
-        cur.close()
-        
+        total_pnl = sum(_to_float(r.get("pnl_pct")) for r in closed_rows)
+
         return {
             "signals_24h": signals_24h,
             "trades_24h": trades_24h,
             "open_positions": open_positions,
             "win_rate_7d": win_rate,
-            "total_pnl_7d": total_pnl
+            "total_pnl_7d": total_pnl,
         }
-    
+
     def get_recent_trades(self, limit: int = 10) -> List[Dict]:
         """Get most recent trades."""
-        cur = self.conn.cursor()
-        
-        cur.execute("""
-            SELECT 
-                token_symbol, strategy, entry_price, exit_price,
-                pnl_pct, status, notes, opened_at, closed_at
-            FROM trades
-            ORDER BY opened_at DESC
-            LIMIT %s
-        """, (limit,))
-        
+        rows = select(
+            "trades",
+            columns="token_symbol,strategy,entry_price,exit_price,pnl_pct,status,notes,opened_at,closed_at",
+            order="opened_at.desc",
+            limit=limit,
+        )
+
         trades = []
-        for row in cur.fetchall():
+        for row in rows:
             trades.append({
-                "token_symbol": row[0],
-                "strategy": row[1],
-                "entry_price": float(row[2]) if row[2] else 0,
-                "exit_price": float(row[3]) if row[3] else 0,
-                "pnl_pct": float(row[4]) if row[4] else 0,
-                "status": row[5],
-                "notes": row[6],
-                "opened_at": row[7].isoformat() if row[7] else "",
-                "closed_at": row[8].isoformat() if row[8] else ""
+                "token_symbol": row.get("token_symbol", ""),
+                "strategy": row.get("strategy", ""),
+                "entry_price": _to_float(row.get("entry_price")),
+                "exit_price": _to_float(row.get("exit_price")),
+                "pnl_pct": _to_float(row.get("pnl_pct")),
+                "status": row.get("status", ""),
+                "notes": row.get("notes", ""),
+                "opened_at": row.get("opened_at", ""),
+                "closed_at": row.get("closed_at", ""),
             })
-        
-        cur.close()
         return trades
-    
+
     def get_signal_breakdown(self) -> Dict:
         """Get signal count by source."""
-        cur = self.conn.cursor()
-        
-        cur.execute("""
-            SELECT source, COUNT(*)
-            FROM signals
-            WHERE timestamp >= NOW() - INTERVAL '24 hours'
-            GROUP BY source
-        """)
-        
-        breakdown = {}
-        for row in cur.fetchall():
-            breakdown[row[0]] = row[1]
-        
-        cur.close()
+        cutoff_24h = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        rows = select(
+            "signals",
+            columns="source",
+            filters={"timestamp": f"gte.{cutoff_24h}"},
+            limit=10000,
+        )
+
+        breakdown: Dict[str, int] = {}
+        for row in rows:
+            src = row.get("source", "unknown")
+            breakdown[src] = breakdown.get(src, 0) + 1
         return breakdown
     
     def generate_html(self) -> str:
@@ -425,17 +407,11 @@ class DashboardGenerator:
             f.write(html)
         
         print(f"Dashboard saved to {output_path}")
-    
-    def close(self):
-        self.conn.close()
 
 
 def main():
     generator = DashboardGenerator()
-    try:
-        generator.save_dashboard()
-    finally:
-        generator.close()
+    generator.save_dashboard()
 
 
 if __name__ == "__main__":

--- a/intelligent_risk_manager.py
+++ b/intelligent_risk_manager.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 from supabase_client import is_available, select
 

--- a/multi_signal_scorer.py
+++ b/multi_signal_scorer.py
@@ -202,7 +202,7 @@ class MultiSignalScorer:
         print(f"Total Score: {score_data['total_score']:.3f} {'✅' if score_data['meets_threshold'] else '❌'}")
         print(f"Confidence: {score_data['confidence']:.2f}")
         print(f"Sources: {score_data['source_count']}")
-        print(f"\nSource Breakdown:")
+        print("\nSource Breakdown:")
 
         for source, data in score_data['source_scores'].items():
             weight = self.weights.get(source, 0)

--- a/onchain_monitor.py
+++ b/onchain_monitor.py
@@ -8,6 +8,7 @@ Uses OKX onchainos token endpoints + Supabase REST only.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
@@ -25,6 +26,7 @@ class OnchainMonitor:
         self.whale_threshold = 100_000  # $100K+ transactions
         self.min_holders = 100
         self.max_top10_concentration = 0.5  # Top 10 holders < 50%
+        self.max_tokens_per_run = int(os.getenv("ONCHAIN_MONITOR_MAX_TOKENS", "60"))
 
     def _run_json(self, args: List[str], timeout: int = 30) -> Optional[Dict]:
         try:
@@ -260,6 +262,10 @@ class OnchainMonitor:
                 continue
             seen.add(key)
             tokens.append((addr, sym, chain))
+
+        if len(tokens) > self.max_tokens_per_run:
+            print(f"Token universe {len(tokens)} too large, capping to {self.max_tokens_per_run}")
+            tokens = tokens[: self.max_tokens_per_run]
 
         print(f"Monitoring {len(tokens)} tokens...")
 

--- a/signal_monitor.py
+++ b/signal_monitor.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-import sys
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
@@ -91,6 +90,18 @@ class SignalMonitor:
 
         return 0.0
 
+    @staticmethod
+    def _normalize_timestamp(raw_ts) -> str:
+        """Convert onchainos millisecond epoch or ISO string to ISO 8601."""
+        if not raw_ts:
+            return datetime.now(timezone.utc).isoformat()
+        s = str(raw_ts).strip()
+        # Millisecond epoch (all digits, 13+ chars)
+        if s.isdigit() and len(s) >= 13:
+            return datetime.fromtimestamp(int(s) / 1000, tz=timezone.utc).isoformat()
+        # Already ISO-ish
+        return s or datetime.now(timezone.utc).isoformat()
+
     def store_signals(self, signals: List[Dict]):
         """Store signals in Supabase."""
         if not signals:
@@ -107,7 +118,7 @@ class SignalMonitor:
                     "chain": sig["chain"],
                     "signal_score": round(score, 3),
                     "raw_data": sig.get("raw_data", {}),
-                    "timestamp": sig.get("timestamp") or datetime.now(timezone.utc).isoformat(),
+                    "timestamp": self._normalize_timestamp(sig.get("timestamp")),
                     "processed": False,
                 }
             )

--- a/strategy_engine.py
+++ b/strategy_engine.py
@@ -132,7 +132,21 @@ class StrategyEngine:
         for (token_addr, chain), sigs in token_signals.items():
             token_symbol = sigs[0]["token_symbol"]
 
-            # Market sanity filters first
+            sources = {s["source"] for s in sigs}
+
+            # Enforce real multi-source confirmation before expensive API calls.
+            if "smart_money" not in sources:
+                continue
+            if "twitter_kol" not in sources:
+                continue
+            if not ({"news", "onchain", "technical"} & sources):
+                continue
+
+            max_score = max(s["signal_score"] for s in sigs)
+            if max_score < 0.7:
+                continue
+
+            # Market sanity filters (after source/score gating to reduce API pressure)
             token_info = self.get_token_market_info(token_symbol, token_addr, chain)
             if not token_info:
                 print(f"  Skipped {token_symbol}: cannot fetch market info", file=sys.stderr)
@@ -162,20 +176,6 @@ class StrategyEngine:
                     f"  Skipped {token_symbol}: liquidity ${liquidity:,.0f} < ${min_liquidity:,.0f}",
                     file=sys.stderr,
                 )
-                continue
-
-            sources = {s["source"] for s in sigs}
-
-            # Enforce real multi-source confirmation
-            if "smart_money" not in sources:
-                continue
-            if "twitter_kol" not in sources:
-                continue
-            if not ({"news", "onchain", "technical"} & sources):
-                continue
-
-            max_score = max(s["signal_score"] for s in sigs)
-            if max_score < 0.7:
                 continue
 
             risk_score = self.get_token_risk_score(token_addr, chain)

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import urllib.parse
 import urllib.request
 from typing import Any, Dict, List, Optional
 
@@ -61,7 +62,7 @@ def select(
     if limit:
         params["limit"] = str(limit)
 
-    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    qs = urllib.parse.urlencode(params, safe="*,.()")
     url = f"{BASE_URL}/rest/v1/{table}?{qs}"
 
     req = urllib.request.Request(url, headers=_headers(), method="GET")
@@ -80,13 +81,15 @@ def insert(table: str, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     if not rows:
         return []
 
-    # Ensure JSON serialization for complex columns
+    # Ensure JSON serialization for complex columns; convert Decimal/datetime
     sanitized = []
     for r in rows:
         s = {}
         for k, v in r.items():
             if isinstance(v, (dict, list)):
                 s[k] = json.dumps(v)
+            elif hasattr(v, "isoformat"):
+                s[k] = v.isoformat()
             else:
                 s[k] = v
         sanitized.append(s)
@@ -115,10 +118,10 @@ def update(
     if not is_available():
         raise RuntimeError("Supabase REST not configured")
 
-    params = {}
+    params: Dict[str, str] = {}
     params = _build_filters(params, filters)
 
-    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    qs = urllib.parse.urlencode(params, safe="*,.()")
     url = f"{BASE_URL}/rest/v1/{table}?{qs}"
 
     # Ensure JSON serialization
@@ -126,6 +129,8 @@ def update(
     for k, v in updates.items():
         if isinstance(v, (dict, list)):
             payload[k] = json.dumps(v)
+        elif hasattr(v, "isoformat"):
+            payload[k] = v.isoformat()
         else:
             payload[k] = v
 
@@ -148,10 +153,10 @@ def delete(table: str, filters: Optional[Dict[str, str]] = None) -> None:
     if not is_available():
         raise RuntimeError("Supabase REST not configured")
 
-    params = {}
+    params: Dict[str, str] = {}
     params = _build_filters(params, filters)
 
-    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    qs = urllib.parse.urlencode(params, safe="*,.()")
     url = f"{BASE_URL}/rest/v1/{table}?{qs}"
 
     req = urllib.request.Request(

--- a/tests/test_token_resolver.py
+++ b/tests/test_token_resolver.py
@@ -1,5 +1,3 @@
-import json
-
 import token_resolver
 from token_resolver import resolve_symbol
 


### PR DESCRIPTION
## Why
Pipeline regressed after a496a2f with HTTP 400 failures and dashboard crash.

## What
- Fix Supabase REST query encoding in `supabase_client` (`urlencode`, typed params)
- Normalize onchainos millisecond timestamps before inserting (`signal_monitor`)
- Remove CI lint blocker in tests (`tests/test_token_resolver.py`)
- Migrate `dashboard_generator` to Supabase REST (remove fragile psycopg2 cursor path)
- Reduce API pressure in `strategy_engine` by gating source/score before market lookups
- Add run-time cap for onchain universe (`ONCHAIN_MONITOR_MAX_TOKENS`, default 60)
- Minor lint cleanups

## Validation
- `ruff check token_auditor.py news_monitor.py price_fetcher.py strategy_engine.py position_monitor.py technical_indicators.py live_trading_manager.py tests`
- `mypy --ignore-missing-imports token_auditor.py news_monitor.py price_fetcher.py`
- `pytest -q` (15 passed)
- Full local workflow sequence with real Supabase + 6551 tokens:
  `signal_monitor -> news_monitor -> twitter_kol_monitor -> onchain_monitor -> technical_indicators -> multi_signal_scorer -> intelligent_risk_manager -> strategy_engine -> position_monitor -> live_trading_manager -> dashboard_generator`
  all steps exit code 0
